### PR TITLE
Support for other types of ids

### DIFF
--- a/store.js
+++ b/store.js
@@ -137,6 +137,7 @@ class MongoStore extends Store {
    * @memberOf MongoStore
    */
   updateById(req, data) {
+    var id
     try {
       id = this.ObjectID(req.id)
     } catch(err) {
@@ -204,6 +205,7 @@ class MongoStore extends Store {
    * @memberOf MongoStore
    */
   findById(req) {
+    var id
     try {
       id = this.ObjectID(req.id)
     } catch(err) {
@@ -257,6 +259,7 @@ class MongoStore extends Store {
    * @memberof MongoStore
    */
   replaceById(req, data) {
+    var id
     try {
       id = this.ObjectID(req.id)
     } catch(err) {

--- a/store.js
+++ b/store.js
@@ -2,6 +2,13 @@
 
 const Store = require('hemera-store')
 
+idRegex = /^[a-f\d]{24}$/i
+
+getId = function (ObjectID,id) {
+  if (idRegex.test(id)) return ObjectID(id)
+  return id
+}
+
 /**
  *
  *
@@ -88,23 +95,17 @@ class MongoStore extends Store {
    * @memberOf MongoStore
    */
   removeById(req) {
-    var id
-    try {
-      id = this.ObjectID(req.id)
-    } catch(err) {
-      id = req.id
-    }
     if (this.options.store.removeById) {
       return this._driver.findOneAndDelete(
         {
-          _id: id
+          _id: getId(this.ObjectID,req.id)
         },
         this.options.store.removeById
       )
     }
 
     return this._driver.findOneAndDelete({
-      _id: id
+      _id: getId(this.ObjectID,req.id)
     })
   }
 
@@ -137,16 +138,10 @@ class MongoStore extends Store {
    * @memberOf MongoStore
    */
   updateById(req, data) {
-    var id
-    try {
-      id = this.ObjectID(req.id)
-    } catch(err) {
-      id = req.id
-    }    
     if (this.options.store.updateById) {
       return this._driver.findOneAndUpdate(
         {
-          _id: id
+          _id: getId(this.ObjectID,req.id)
         },
         data,
         this.options.store.updateById
@@ -155,7 +150,7 @@ class MongoStore extends Store {
 
     return this._driver.findOneAndUpdate(
       {
-        _id: id
+        _id: getId(this.ObjectID,req.id)
       },
       data
     )
@@ -205,23 +200,17 @@ class MongoStore extends Store {
    * @memberOf MongoStore
    */
   findById(req) {
-    var id
-    try {
-      id = this.ObjectID(req.id)
-    } catch(err) {
-      id = req.id
-    }    
     if (this.options.store.findById) {
       return this._driver.findOne(
         {
-          _id: id
+          _id: getId(this.ObjectID,req.id)
         },
         this.options.store.findById
       )
     }
 
     return this._driver.findOne({
-      _id: id
+      _id: getId(this.ObjectID,req.id)
     })
   }
 
@@ -259,16 +248,10 @@ class MongoStore extends Store {
    * @memberof MongoStore
    */
   replaceById(req, data) {
-    var id
-    try {
-      id = this.ObjectID(req.id)
-    } catch(err) {
-      id = req.id
-    }    
     if (this.options.store.replaceById) {
       return this._driver.findOneAndReplace(
         {
-          _id: id
+          _id: getId(this.ObjectID,req.id)
         },
         data,
         this.options.store.replaceById
@@ -277,7 +260,7 @@ class MongoStore extends Store {
 
     return this._driver.findOneAndReplace(
       {
-        _id: id
+        _id: getId(this.ObjectID,req.id)
       },
       data
     )

--- a/store.js
+++ b/store.js
@@ -88,17 +88,23 @@ class MongoStore extends Store {
    * @memberOf MongoStore
    */
   removeById(req) {
+    var id
+    try {
+      id = this.ObjectID(req.id)
+    } catch(err) {
+      id = req.id
+    }
     if (this.options.store.removeById) {
       return this._driver.findOneAndDelete(
         {
-          _id: this.ObjectID(req.id)
+          _id: id
         },
         this.options.store.removeById
       )
     }
 
     return this._driver.findOneAndDelete({
-      _id: this.ObjectID(req.id)
+      _id: id
     })
   }
 
@@ -131,10 +137,15 @@ class MongoStore extends Store {
    * @memberOf MongoStore
    */
   updateById(req, data) {
+    try {
+      id = this.ObjectID(req.id)
+    } catch(err) {
+      id = req.id
+    }    
     if (this.options.store.updateById) {
       return this._driver.findOneAndUpdate(
         {
-          _id: this.ObjectID(req.id)
+          _id: id
         },
         data,
         this.options.store.updateById
@@ -143,7 +154,7 @@ class MongoStore extends Store {
 
     return this._driver.findOneAndUpdate(
       {
-        _id: this.ObjectID(req.id)
+        _id: id
       },
       data
     )
@@ -193,17 +204,22 @@ class MongoStore extends Store {
    * @memberOf MongoStore
    */
   findById(req) {
+    try {
+      id = this.ObjectID(req.id)
+    } catch(err) {
+      id = req.id
+    }    
     if (this.options.store.findById) {
       return this._driver.findOne(
         {
-          _id: this.ObjectID(req.id)
+          _id: id
         },
         this.options.store.findById
       )
     }
 
     return this._driver.findOne({
-      _id: this.ObjectID(req.id)
+      _id: id
     })
   }
 
@@ -241,10 +257,15 @@ class MongoStore extends Store {
    * @memberof MongoStore
    */
   replaceById(req, data) {
+    try {
+      id = this.ObjectID(req.id)
+    } catch(err) {
+      id = req.id
+    }    
     if (this.options.store.replaceById) {
       return this._driver.findOneAndReplace(
         {
-          _id: this.ObjectID(req.id)
+          _id: id
         },
         data,
         this.options.store.replaceById
@@ -253,7 +274,7 @@ class MongoStore extends Store {
 
     return this._driver.findOneAndReplace(
       {
-        _id: this.ObjectID(req.id)
+        _id: id
       },
       data
     )

--- a/store.js
+++ b/store.js
@@ -4,7 +4,7 @@ const Store = require('hemera-store')
 
 var idRegex = /^[a-f\d]{24}$/i
 
-getId = function (ObjectID,id) {
+var getId = function (ObjectID,id) {
   if (idRegex.test(id)) return ObjectID(id)
   return id
 }

--- a/store.js
+++ b/store.js
@@ -2,7 +2,7 @@
 
 const Store = require('hemera-store')
 
-idRegex = /^[a-f\d]{24}$/i
+var idRegex = /^[a-f\d]{24}$/i
 
 getId = function (ObjectID,id) {
   if (idRegex.test(id)) return ObjectID(id)


### PR DESCRIPTION
I have a legacy mongo database where not all ids are of type ObjectId.

It would be great if the plugin could try do not use ObjectId if the id is not compatible with the ObjectID.

Thanks and congrats for you great work.